### PR TITLE
增添对歌曲链接中“/#”的识别

### DIFF
--- a/main.js
+++ b/main.js
@@ -61,8 +61,8 @@ function simulateInput(element, val) {
 
 window.addEventListener('paste', function (event) {
     const data = (event.clipboardData || event.originalEvent.clipboardData)
-    const regexGetNCMId = /music\.163\.com\/song\?id=(\d+)/
-    const id = regexGetNCMId.exec(data.getData('text'))?.[1]
+    const regexGetNCMId = /music\.163\.com(\/#)?\/song\?id=(\d+)/
+    const id = regexGetNCMId.exec(data.getData('text'))?.[2]
 
     if (id && id.length >= 5) {
         const jsInput = document.querySelector('.j-search-input, .searchbox .cmd-input')


### PR DESCRIPTION
在有些分享连接中，比如微信卡片，链接长这样：
`music.163.com/#/song?id=114514`
比普通的多了个井号，识别不出来了

改了一下正则表达式，这样两种形式的链接就都能匹配了